### PR TITLE
Implement graduates data endpoint

### DIFF
--- a/courses/tests/test_data.py
+++ b/courses/tests/test_data.py
@@ -2,9 +2,9 @@ from django.test import TestCase, Client
 from django.urls import reverse
 from django.utils import timezone
 from django.core.exceptions import ValidationError
+from hashlib import sha1
 
 from courses.models import (
-    User,
     Course,
     Homework,
     Submission,
@@ -15,6 +15,7 @@ from courses.models import (
     Answer,
     Project,
     ProjectSubmission,
+    ProjectState,
 )
 
 from accounts.models import CustomUser, Token
@@ -382,3 +383,46 @@ class DataAPITestCase(TestCase):
         )
         with self.assertRaises(ValidationError):
             self.project_submission.full_clean()
+
+    def test_graduates_data_view(self):
+        project = Project.objects.create(
+            course=self.course,
+            slug="proj",
+            title="Project",
+            description="Description",
+            submission_due_date=timezone.now() + timezone.timedelta(days=7),
+            peer_review_due_date=timezone.now() + timezone.timedelta(days=14),
+            state=ProjectState.COMPLETED.value,
+        )
+
+        submission = ProjectSubmission(
+            project=project,
+            student=self.user,
+            enrollment=self.enrollment,
+            github_link="https://github.com/DataTalksClub/project",
+            commit_id="abcd1234",
+            passed=True,
+        )
+        submission.full_clean()
+        submission.save()
+
+        url = reverse(
+            "data_graduates",
+            kwargs={"course_slug": self.course.slug},
+        )
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+
+        expected_hash = sha1((self.user.email.lower().strip() + "_").encode("utf-8")).hexdigest()
+        self.assertEqual(
+            data["results"],
+            [
+                {
+                    "email": self.user.email,
+                    "name": self.enrollment.display_name,
+                    "hash": expected_hash,
+                }
+            ],
+        )

--- a/courses/urls.py
+++ b/courses/urls.py
@@ -85,6 +85,11 @@ urlpatterns = [
         name="data_homework",
     ),
     path(
+        "data/<slug:course_slug>/graduates",
+        data.graduates_data_view,
+        name="data_graduates",
+    ),
+    path(
         "data/<slug:course_slug>/project/<slug:project_slug>",
         data.project_data_view,
         name="data_project",

--- a/courses/views/data.py
+++ b/courses/views/data.py
@@ -2,6 +2,7 @@ from django.http import JsonResponse
 from accounts.auth import token_required
 from django.shortcuts import get_object_or_404
 from django.db.models import Prefetch
+from hashlib import sha1
 
 from courses.models import (
     Answer,
@@ -62,6 +63,40 @@ def homework_data_view(request, course_slug: str, homework_slug: str):
     }
 
     return JsonResponse(result)
+
+
+@token_required
+def graduates_data_view(request, course_slug: str):
+    """Return information about course graduates."""
+    course = get_object_or_404(Course, slug=course_slug)
+
+    submissions = (
+        ProjectSubmission.objects.filter(project__course=course, passed=True)
+        .select_related("enrollment__student")
+        .all()
+    )
+
+    seen = set()
+    results = []
+
+    for submission in submissions:
+        enrollment = submission.enrollment
+        student = enrollment.student
+
+        email = student.email
+        if email in seen:
+            continue
+
+        name = enrollment.certificate_name or enrollment.display_name
+
+        # same logic as in the notebooks
+        email_clean = email.lower().strip()
+        cert_hash = sha1((email_clean + "_").encode("utf-8")).hexdigest()
+
+        results.append({"email": email, "name": name, "hash": cert_hash})
+        seen.add(email)
+
+    return JsonResponse({"results": results})
 
 
 @token_required


### PR DESCRIPTION
## Summary
- add `graduates_data_view` endpoint to expose graduate info
- route new endpoint in course URLs
- test graduates data API

## Testing
- `ruff check courses/views/data.py courses/urls.py courses/tests/test_data.py`
- `pytest -k test_graduates_data_view -vv` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_686797183f1c83308a42a5b215a0c785