### PR TITLE
Rename Active courses to Running courses

### DIFF
--- a/courses/templates/courses/course_list.html
+++ b/courses/templates/courses/course_list.html
@@ -7,7 +7,7 @@
     our courses in our webpage <a href="https://datatalks.club/" target="_blank">https://datatalks.club/</a>.
   </div>
 
-  <h3 class="pt-4">Active courses</h3>
+  <h3 class="pt-4">Running courses</h3>
   <ul>
     {% for course in active_courses %}
       <li><a href="{% url 'course' course.slug %}">{{ course.title }}</a></li>


### PR DESCRIPTION
## Summary
- rename the Active courses heading to Running courses on the course list page

## Testing
- `pytest` *(fails: Unknown config option: DJANGO_SETTINGS_MODULE)*

------
https://chatgpt.com/codex/tasks/task_e_688b36a251788324a5614f64e09ba5dd